### PR TITLE
Github action to comment on pull requests automatically

### DIFF
--- a/.github/workflows/close-pr-comment.yml
+++ b/.github/workflows/close-pr-comment.yml
@@ -3,9 +3,9 @@ on:
     types: [closed]
 
 jobs:
-  open_pr_comment:
+  closed_pr_comment:
     runs-on: ubuntu-latest
-    name: Comment on opened pull request
+    name: Comment on closed pull request
     permissions: 
       pull-requests: write 
     

--- a/.github/workflows/close-pr-comment.yml
+++ b/.github/workflows/close-pr-comment.yml
@@ -1,0 +1,24 @@
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  open_pr_comment:
+    runs-on: ubuntu-latest
+    name: Comment on opened pull request
+    permissions: 
+      pull-requests: write 
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Your pull request has been closed @${{github.event.pull_request.user.login}}!
+            
+            Thank you for your contribution to this project! :heart:
+            
+          reactions: heart, rocket

--- a/.github/workflows/open-pr-comment.yml
+++ b/.github/workflows/open-pr-comment.yml
@@ -1,0 +1,26 @@
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  open_pr_comment:
+    runs-on: ubuntu-latest
+    name: Comment on opened pull request
+    permissions: 
+      pull-requests: write 
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Hey @${{github.event.pull_request.user.login}}!
+            
+            Thank you for opening a pull request and contributing to this project! :heart:
+
+            A maitainer will be reviewing it as soon as possible.
+            
+          reactions: heart, rocket


### PR DESCRIPTION
Closes #5 

**Changes**
Added two workflow files which get run when a pr is opened and closed respectively.
The comments that get added to the pr are as seen bellow.

Opening:
![image](https://github.com/jatiinyadav/web-crawler/assets/60406199/2d99a73d-9df4-4652-b595-38f6700e2428)

Closing:
![image](https://github.com/jatiinyadav/web-crawler/assets/60406199/e6f414d6-e8a0-44da-b2bb-f0dfc8f497d0)
